### PR TITLE
chore: update Java version to 17 and add ruleset base dir to POMs

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -15,16 +15,16 @@ env:
 
 jobs:
   build:
-    name: Build Ledgers (openjdk 1.11)
+    name: Build Ledgers (openjdk 17)
     runs-on: ubuntu-latest
     steps:
       - name: Clone ledgers develop repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
           architecture: x64
 
       - name: Cache Maven packages
@@ -45,10 +45,10 @@ jobs:
       - name: Clone ledgers develop repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
           architecture: x64
 
       - name: Cache Maven packages
@@ -72,10 +72,10 @@ jobs:
       - name: Clone ledgers develop repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
           architecture: x64
 
       - name: Cache Maven packages
@@ -99,10 +99,10 @@ jobs:
       - name: Clone ledgers develop repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
           architecture: x64
 
       - name: Cache Maven packages
@@ -123,10 +123,10 @@ jobs:
       - name: Clone ledgers develop repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
           architecture: x64
 
       - name: Cache Maven packages
@@ -160,10 +160,10 @@ jobs:
       - name: Clone ledgers develop repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 17 for x64
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
           architecture: x64
 
       - name: Cache Maven packages

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/pom.xml
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/pom.xml
@@ -16,11 +16,13 @@
     </parent>
 
     <artifactId>ledgers-bank-account-access-repository</artifactId>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ruleset.basedir>../..</ruleset.basedir>
     </properties>
 
 </project>

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-rest-api/pom.xml
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-rest-api/pom.xml
@@ -17,10 +17,12 @@
 
     <artifactId>ledgers-bank-account-access-rest-api</artifactId>
 
+
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ruleset.basedir>../..</ruleset.basedir>
     </properties>
 
 </project>

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-rest-server/pom.xml
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-rest-server/pom.xml
@@ -16,11 +16,14 @@
     </parent>
 
     <artifactId>ledgers-bank-account-access-rest-server</artifactId>
+    <packaging>jar</packaging>
+
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ruleset.basedir>../..</ruleset.basedir>
     </properties>
 
 </project>

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-service-api/pom.xml
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-service-api/pom.xml
@@ -16,11 +16,13 @@
     </parent>
 
     <artifactId>ledgers-bank-account-access-service-api</artifactId>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ruleset.basedir>../..</ruleset.basedir>
     </properties>
 
 </project>

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-service-impl/pom.xml
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-service-impl/pom.xml
@@ -16,11 +16,13 @@
     </parent>
 
     <artifactId>ledgers-bank-account-access-service-impl</artifactId>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ruleset.basedir>../..</ruleset.basedir>
     </properties>
 
 </project>

--- a/ledgers-bank-account-access-management/pom.xml
+++ b/ledgers-bank-account-access-management/pom.xml
@@ -12,6 +12,7 @@
         <groupId>de.adorsys.ledgers</groupId>
         <artifactId>ledgers</artifactId>
         <version>6.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>ledgers-bank-account-access-management</artifactId>


### PR DESCRIPTION
Updated Java version from 11 to 17 in develop.yaml for improved compatibility and feature support.
Added ruleset.basedir property in multiple POM files to standardize the base directory for PMD rule configurations.

**Impact:**
Aligns the project with Java 17 for modern language features.
Ensures consistent rule checks across modules with the ruleset base directory configuration.
