### PR TITLE
Issue-19: Add ManagerAccess entity, repository, and related enums

### DIFF
--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/pom.xml
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/pom.xml
@@ -34,6 +34,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
         <!-- spring dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ManagerAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ManagerAccess.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -29,12 +30,10 @@ public class ManagerAccess {
     @Enumerated(EnumType.STRING)
     private AccessStatus status;
 
-    @ElementCollection(targetClass = TypeOfManagedAccess.class)
-    @Enumerated(EnumType.STRING)
-    private Set<TypeOfManagedAccess> managedAccessTypes;
+    @ElementCollection
+    private Set<TypeOfManagedAccess> managedAccessTypes = new HashSet<>();
 
-    @ElementCollection(targetClass = ScopeOfManagerAccess.class)
-    @Enumerated(EnumType.STRING)
-    private Set<ScopeOfManagerAccess> scopeOfAccess;
+    @ElementCollection
+    private Set<ScopeOfManagerAccess> scopeOfAccess = new HashSet<>();
 
 }

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ManagerAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ManagerAccess.java
@@ -1,0 +1,40 @@
+package de.adorsys.ledgers.baam.db.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ManagerAccess {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+
+    @Min(0)
+    @Max(1)
+    private double weight; // Level of access (0 to 1)
+
+    @Enumerated(EnumType.STRING)
+    private AccessStatus status;
+
+    @ElementCollection(targetClass = TypeOfManagedAccess.class)
+    @Enumerated(EnumType.STRING)
+    private Set<TypeOfManagedAccess> managedAccessTypes;
+
+    @ElementCollection(targetClass = ScopeOfManagerAccess.class)
+    @Enumerated(EnumType.STRING)
+    private Set<ScopeOfManagerAccess> scopeOfAccess;
+
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ScopeOfManagerAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ScopeOfManagerAccess.java
@@ -3,6 +3,6 @@ package de.adorsys.ledgers.baam.db.domain;
 public enum ScopeOfManagerAccess {
     MANAGE_ACCESS,
     VIEW_ACCOUNT_DETAILS,
-    EXECUTE_TRANSACTIONS;
+    EXECUTE_TRANSACTIONS, VIEW_ACCOUNT;
 
 }

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ScopeOfManagerAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/ScopeOfManagerAccess.java
@@ -1,0 +1,8 @@
+package de.adorsys.ledgers.baam.db.domain;
+
+public enum ScopeOfManagerAccess {
+    MANAGE_ACCESS,
+    VIEW_ACCOUNT_DETAILS,
+    EXECUTE_TRANSACTIONS;
+
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/SeniorManagerAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/SeniorManagerAccess.java
@@ -1,0 +1,19 @@
+package de.adorsys.ledgers.baam.db.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeniorManagerAccess {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/TypeOfManagedAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/domain/TypeOfManagedAccess.java
@@ -1,0 +1,8 @@
+package de.adorsys.ledgers.baam.db.domain;
+
+public enum TypeOfManagedAccess {
+    AGENT_ACCESS,
+    AUDITOR_ACCESS,
+    POA_ACCESS;
+
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepository.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/main/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepository.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018-2023 adorsys GmbH and Co. KG
+ * All rights are reserved.
+ */
+
+package de.adorsys.ledgers.baam.db.repository;
+
+
+import de.adorsys.ledgers.baam.db.domain.ManagerAccess;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ManagerAccessRepository extends JpaRepository<ManagerAccess, UUID> {
+
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/domain/ExampleManagerAccess.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/domain/ExampleManagerAccess.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018-2023 adorsys GmbH and Co. KG
+ * All rights are reserved.
+ */
+
+package de.adorsys.ledgers.baam.db.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+
+@Entity
+@Table (name = "manager_access")
+public class ExampleManagerAccess  extends ManagerAccess {
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepositoryIT.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepositoryIT.java
@@ -1,0 +1,108 @@
+package de.adorsys.ledgers.baam.db.repository;
+
+import de.adorsys.ledgers.baam.db.domain.AccessStatus;
+import de.adorsys.ledgers.baam.db.domain.ManagerAccess;
+import de.adorsys.ledgers.baam.db.domain.TypeOfManagedAccess;
+import de.adorsys.ledgers.baam.db.domain.ScopeOfManagerAccess;
+import de.adorsys.ledgers.baam.db.test.BaamRepositoryApplication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import jakarta.transaction.Transactional;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = BaamRepositoryApplication.class)
+@Transactional // Ensures that each test is executed within a transaction and rolled back afterwards
+@Rollback // Reverts the changes made to the database after each test
+public class ManagerAccessRepositoryIT {
+
+
+    @Autowired
+    private ManagerAccessRepository managerAccessRepository;
+
+    // Variable to store a ManagerAccess object
+    private ManagerAccess managerAccess;
+
+    @BeforeEach
+    public void setup() {
+        // Initialize a ManagerAccess object for testing
+        managerAccess = new ManagerAccess();
+        managerAccess.setName("John Doe");
+        managerAccess.setWeight(0.8);
+        managerAccess.setStatus(AccessStatus.ACTIVE);
+        managerAccess.setManagedAccessTypes(new HashSet<>(Set.of(TypeOfManagedAccess.AGENT_ACCESS)));
+        managerAccess.setScopeOfAccess(new HashSet<>(Set.of(ScopeOfManagerAccess.VIEW_ACCOUNT)));
+    }
+
+    @Test
+    public void testCreateManagerAccess() {
+        // Save to the database via the injected repository
+        ManagerAccess savedManager = managerAccessRepository.save(managerAccess);
+
+        // Verify that the object is properly saved and has a generated ID
+        assertThat(savedManager.getId()).isNotNull();
+    }
+
+    @Test
+    public void testFindManagerAccessById() {
+        // Save the ManagerAccess entity to the database
+        managerAccessRepository.save(managerAccess);
+        UUID managerId = managerAccess.getId();
+
+        // Retrieve the ManagerAccess object from the database using the ID
+        ManagerAccess foundManager = managerAccessRepository.findById(managerId).orElse(null);
+
+        // Verify that the retrieved object matches the one that was saved
+        assertThat(foundManager).isNotNull();
+        assertThat(foundManager.getName()).isEqualTo("John Doe");
+        assertThat(foundManager.getWeight()).isEqualTo(0.8);
+        assertThat(foundManager.getStatus()).isEqualTo(AccessStatus.ACTIVE);
+        assertThat(foundManager.getManagedAccessTypes()).contains(TypeOfManagedAccess.AGENT_ACCESS);
+        assertThat(foundManager.getScopeOfAccess()).contains(ScopeOfManagerAccess.VIEW_ACCOUNT);
+    }
+
+    @Test
+    public void testUpdateManagerAccess() {
+        // Initially save a ManagerAccess
+        managerAccessRepository.save(managerAccess);
+
+        // Modify the details of the ManagerAccess
+        managerAccess.setName("Jane Doe");
+        managerAccess.setWeight(1.0);
+        managerAccess.setStatus(AccessStatus.RESTRICTED);
+
+        Set<ScopeOfManagerAccess> newScopes = new HashSet<>();
+        newScopes.add(ScopeOfManagerAccess.EXECUTE_TRANSACTIONS);
+        managerAccess.setScopeOfAccess(newScopes);
+        // Update the record
+        ManagerAccess updatedManager = managerAccessRepository.save(managerAccess);
+
+        // Verify that the information has been updated correctly
+        assertThat(updatedManager.getName()).isEqualTo("Jane Doe");
+        assertThat(updatedManager.getWeight()).isEqualTo(1.0);
+        assertThat(updatedManager.getStatus()).isEqualTo(AccessStatus.RESTRICTED);
+        assertThat(updatedManager.getScopeOfAccess()).contains(ScopeOfManagerAccess.EXECUTE_TRANSACTIONS);
+    }
+
+    @Test
+    public void testDeleteManagerAccess() {
+        // Save a ManagerAccess to the database
+        managerAccessRepository.save(managerAccess);
+        UUID managerId = managerAccess.getId();
+
+        // Delete the record
+        managerAccessRepository.deleteById(managerId);
+
+        // Verify that the entity has been successfully deleted
+        ManagerAccess deletedManager = managerAccessRepository.findById(managerId).orElse(null);
+        assertThat(deletedManager).isNull();
+    }
+}

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepositoryTest.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepositoryTest.java
@@ -5,8 +5,15 @@
 
 package de.adorsys.ledgers.baam.db.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import de.adorsys.ledgers.baam.db.domain.ExampleManagerAccess;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-class ManagerAccessRepositoryTest {
+import java.util.UUID;
+
+
+@Repository
+public interface ManagerAccessRepositoryTest extends JpaRepository<ExampleManagerAccess, UUID> {
+
 
 }

--- a/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepositoryTest.java
+++ b/ledgers-bank-account-access-management/ledgers-bank-account-access-repository/src/test/java/de/adorsys/ledgers/baam/db/repository/ManagerAccessRepositoryTest.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018-2023 adorsys GmbH and Co. KG
+ * All rights are reserved.
+ */
+
+package de.adorsys.ledgers.baam.db.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ManagerAccessRepositoryTest {
+
+}


### PR DESCRIPTION
          - Added ManagerAccess entity with fields for id, name, weight, status, managedAccessTypes, and scopeOfAccess.
          - Introduced validation constraints for weight (0 to 1).
          - Implemented ManagerAccessRepository for CRUD operations.
          - Defined enums ScopeOfManagerAccess and TypeOfManagedAccess to handle various access types and scopes.